### PR TITLE
refactor: add react router v6 to handle new /tx/txhash route

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "ethers": "^5.1.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
+    "react-router-dom": "^6.4.3",
     "react-scripts": "4.0.3",
     "typescript": "^4.4.2",
     "web-vitals": "^1.0.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,6 +26,7 @@ import {
 } from "@arbitrum/sdk/dist/lib/message/L1ToL2Message";
 import { getL2ToL1Messages, L2ToL1MessageData, L2TxnStatus } from "./lib";
 import L2ToL1MsgsDisplay from "./L2ToL1MsgsDisplay";
+import { isValidTxHash } from "./isValidTxHash";
 
 export enum ReceiptState {
   EMPTY,
@@ -520,11 +521,11 @@ function App() {
   };
 
   // simple deep linking
-  let { txhash } = useParams();
+  let { txHash } = useParams();
 
-  if (input === "" && txhash?.length === 66) {
-    setInput(txhash);
-    retryablesSearch(txhash);
+  if (input === "" && isValidTxHash(txHash)) {
+    setInput(txHash);
+    retryablesSearch(txHash);
   }
   const { text: l1TxnResultText } =
     receiptStateToDisplayableResult(txHashState);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -398,7 +398,23 @@ const l1ToL2MessageToStatusDisplay = async (
 };
 
 function App() {
+  const { txHash } = useParams();
   const navigate = useNavigate();
+
+  const oldTxHash = new URLSearchParams(window.location.search).get("t");
+
+  useEffect(() => {
+    if (!oldTxHash) {
+      return;
+    }
+
+    if (isValidTxHash(oldTxHash)) {
+      navigate(generatePath("tx/:txHash", { txHash: oldTxHash }));
+    } else {
+      navigate("/");
+    }
+  }, [navigate, oldTxHash]);
+
   const { connect, disconnect, provider } = useWallet();
   const [connectedNetworkId, setConnectedNetworkID] = useState<number | null>(
     null
@@ -452,7 +468,7 @@ function App() {
     }
 
     // simple deep linking
-    navigate(generatePath("tx/:txhash", { txhash: txHash }));
+    navigate(generatePath("tx/:txHash", { txHash }));
 
     const receiptRes = await getL1TxnReceipt(txHash);
     setl1TxnReceipt(receiptRes);
@@ -521,8 +537,6 @@ function App() {
   };
 
   // simple deep linking
-  let { txHash } = useParams();
-
   if (input === "" && isValidTxHash(txHash)) {
     setInput(txHash);
     retryablesSearch(txHash);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,7 +11,7 @@ import {
   getL2Network,
   L1ToL2MessageReader
 } from "@arbitrum/sdk";
-import { useParams } from "react-router-dom";
+import { useNavigate, useParams, generatePath } from "react-router-dom";
 
 import { ethers } from "ethers";
 import {
@@ -397,6 +397,7 @@ const l1ToL2MessageToStatusDisplay = async (
 };
 
 function App() {
+  const navigate = useNavigate();
   const { connect, disconnect, provider } = useWallet();
   const [connectedNetworkId, setConnectedNetworkID] = useState<number | null>(
     null
@@ -450,7 +451,7 @@ function App() {
     }
 
     // simple deep linking
-    window.history.pushState("", "", `/tx/${txHash}`);
+    navigate(generatePath("tx/:txhash", { txhash: txHash }));
 
     const receiptRes = await getL1TxnReceipt(txHash);
     setl1TxnReceipt(receiptRes);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import {
   getL2Network,
   L1ToL2MessageReader
 } from "@arbitrum/sdk";
+import { useParams } from "react-router-dom";
 
 import { ethers } from "ethers";
 import {
@@ -254,11 +255,11 @@ const getL1ToL2MessagesAndDepositMessages = async (
     allL1ToL2Messages = allL1ToL2Messages.concat(l1ToL2MessagesWithNetwork);
     allDepositMessages = allDepositMessages.concat(depositMessagesWithNetwork);
   }
-  const allMesaages: L1ToL2MessagesAndDepositMessages = {
+  const allMessages: L1ToL2MessagesAndDepositMessages = {
     retryables: allL1ToL2Messages,
     deposits: allDepositMessages
   };
-  return allMesaages;
+  return allMessages;
 };
 
 const depositMessageStatusDisplay = async (
@@ -449,7 +450,7 @@ function App() {
     }
 
     // simple deep linking
-    window.history.pushState("", "", `/?t=${txHash}`);
+    window.history.pushState("", "", `/tx/${txHash}`);
 
     const receiptRes = await getL1TxnReceipt(txHash);
     setl1TxnReceipt(receiptRes);
@@ -476,12 +477,12 @@ function App() {
       return setTxnHashState(ReceiptState.L1_FAILED);
     }
 
-    const allMesaages = await getL1ToL2MessagesAndDepositMessages(
+    const allMessages = await getL1ToL2MessagesAndDepositMessages(
       l1TxnReceipt,
       l1Network
     );
-    const l1ToL2Messages = allMesaages.retryables;
-    const depositMessages = allMesaages.deposits;
+    const l1ToL2Messages = allMessages.retryables;
+    const depositMessages = allMessages.deposits;
 
     if (l1ToL2Messages.length === 0 && depositMessages.length === 0) {
       return setTxnHashState(ReceiptState.NO_L1_L2_MESSAGES);
@@ -518,7 +519,8 @@ function App() {
   };
 
   // simple deep linking
-  const txhash = new URLSearchParams(window.location.search).get("t");
+  let { txhash } = useParams();
+
   if (input === "" && txhash?.length === 66) {
     setInput(txhash);
     retryablesSearch(txhash);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -14,27 +14,12 @@ const router = createBrowserRouter([
   {
     path: "/",
     element: <App />,
-    loader: ({ params }) => {
-      // If the app was accessed through old URL format, redirect
-      const oldTxHash = new URLSearchParams(window.location.search).get("t");
-      const { txHash } = params;
-
-      // This loader is executed when accessing tx/:txhash, we need this check to avoid infinite loop
-      if (txHash || !oldTxHash) {
-        return;
-      }
-
-      if (isValidTxHash(oldTxHash)) {
-        return redirect(`tx/${oldTxHash}`);
-      }
-    },
     children: [
       {
         path: "tx",
         element: null,
         loader: ({ params }) => {
-          const { txHash } = params;
-          if (!txHash || !isValidTxHash(txHash)) {
+          if (!isValidTxHash(params.txHash)) {
             return redirect("/");
           }
         },

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -41,7 +41,7 @@ const router = createBrowserRouter([
         children: [
           {
             path: "/tx/:txHash",
-            element: <App />
+            element: null
           }
         ]
       }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,8 +1,10 @@
 import React from "react";
 import ReactDOM from "react-dom";
 import {
-  createBrowserRouter,
+  RouteObject,
   RouterProvider,
+  createBrowserRouter,
+  matchRoutes,
   redirect
 } from "react-router-dom";
 import "./index.css";
@@ -10,25 +12,39 @@ import App from "./App";
 import logo from "./logo.svg";
 import { isValidTxHash } from "./isValidTxHash";
 
+const routes: RouteObject[] = [
+  {
+    path: "tx",
+    element: null,
+    loader: ({ params }) => {
+      if (!isValidTxHash(params.txHash)) {
+        return redirect("/");
+      }
+    },
+    children: [
+      {
+        path: "/tx/:txHash",
+        element: null
+      }
+    ]
+  }
+];
+
 const router = createBrowserRouter([
   {
     path: "/",
     element: <App />,
     children: [
+      ...routes,
       {
-        path: "tx",
+        path: "*",
         element: null,
-        loader: ({ params }) => {
-          if (!isValidTxHash(params.txHash)) {
+        loader: () => {
+          // 404 route, redirect to base route
+          if (!matchRoutes([...routes, { path: "/" }], window.location)) {
             return redirect("/");
           }
-        },
-        children: [
-          {
-            path: "/tx/:txHash",
-            element: null
-          }
-        ]
+        }
       }
     ]
   }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,8 +1,47 @@
 import React from "react";
 import ReactDOM from "react-dom";
+import {
+  createBrowserRouter,
+  RouterProvider,
+  redirect
+} from "react-router-dom";
 import "./index.css";
 import App from "./App";
 import logo from "./logo.svg";
+
+const router = createBrowserRouter([
+  {
+    path: "/",
+    element: <App />,
+    loader: ({ params }) => {
+      // If the app was accessed through old URL format, redirect
+      const txhash = new URLSearchParams(window.location.search).get("t");
+
+      // This loader is executed when accessing tx/:txhash, we need this check to avoid infinite loop
+      if (txhash?.length === 66 && !params.txhash) {
+        return redirect(`tx/${txhash}`);
+      }
+    },
+    children: [
+      {
+        path: "tx",
+        element: null,
+        loader: ({ params }) => {
+          const { txhash } = params;
+          if (!txhash || txhash.length !== 66) {
+            return redirect("/");
+          }
+        },
+        children: [
+          {
+            path: "/tx/:txhash",
+            element: <App />
+          }
+        ]
+      }
+    ]
+  }
+]);
 
 ReactDOM.render(
   <React.StrictMode>
@@ -10,7 +49,7 @@ ReactDOM.render(
       <header className="Header-header">
         <h2>Arbitrum Cross-chain Message Dashboard</h2>
         <img src={logo} className="Header-logo" alt="logo" />
-        <App />
+        <RouterProvider router={router} />
       </header>
     </div>
   </React.StrictMode>,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -8,6 +8,7 @@ import {
 import "./index.css";
 import App from "./App";
 import logo from "./logo.svg";
+import { isValidTxHash } from "./isValidTxHash";
 
 const router = createBrowserRouter([
   {
@@ -15,11 +16,16 @@ const router = createBrowserRouter([
     element: <App />,
     loader: ({ params }) => {
       // If the app was accessed through old URL format, redirect
-      const txhash = new URLSearchParams(window.location.search).get("t");
+      const oldTxHash = new URLSearchParams(window.location.search).get("t");
+      const { txHash } = params;
 
       // This loader is executed when accessing tx/:txhash, we need this check to avoid infinite loop
-      if (txhash?.length === 66 && !params.txhash) {
-        return redirect(`tx/${txhash}`);
+      if (txHash || !oldTxHash) {
+        return;
+      }
+
+      if (isValidTxHash(oldTxHash)) {
+        return redirect(`tx/${oldTxHash}`);
       }
     },
     children: [
@@ -27,14 +33,14 @@ const router = createBrowserRouter([
         path: "tx",
         element: null,
         loader: ({ params }) => {
-          const { txhash } = params;
-          if (!txhash || txhash.length !== 66) {
+          const { txHash } = params;
+          if (!txHash || !isValidTxHash(txHash)) {
             return redirect("/");
           }
         },
         children: [
           {
-            path: "/tx/:txhash",
+            path: "/tx/:txHash",
             element: <App />
           }
         ]

--- a/src/isValidTxHash.ts
+++ b/src/isValidTxHash.ts
@@ -1,0 +1,8 @@
+function isValidTxHash(txHash: string | undefined): txHash is string {
+  if (!txHash) {
+    return false;
+  }
+  return /^0x([A-Fa-f0-9]{64})$/.test(txHash);
+}
+
+export { isValidTxHash };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1838,6 +1838,11 @@
   resolved "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.21.tgz"
   integrity sha512-a5Sab1C4/icpTZVzZc5Ghpz88yQtGOyNqYXcZgOssB2uuAr+wF/MvN6bgtW32q7HHrvBki+BsZ0OuNv6EV3K9g==
 
+"@remix-run/router@1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@remix-run/router/-/router-1.0.3.tgz#953b88c20ea00d0eddaffdc1b115c08474aa295d"
+  integrity sha512-ceuyTSs7PZ/tQqi19YZNBc5X7kj1f8p+4DIyrcIYFY9h+hd1OKm4RqtiWldR9eGEvIiJfsqwM4BsuCtRIuEw6Q==
+
 "@rollup/plugin-node-resolve@^7.1.1":
   version "7.1.3"
   resolved "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-7.1.3.tgz"
@@ -9612,6 +9617,21 @@ react-refresh@^0.8.3:
   version "0.8.3"
   resolved "https://registry.npmjs.org/react-refresh/-/react-refresh-0.8.3.tgz"
   integrity sha512-X8jZHc7nCMjaCqoU+V2I0cOhNW+QMBwSUkeXnTi8IPe6zaRWfn60ZzvFDZqWPfmSJfjub7dDW1SP0jaHWLu/hg==
+
+react-router-dom@^6.4.3:
+  version "6.4.3"
+  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-6.4.3.tgz#70093b5f65f85f1df9e5d4182eb7ff3a08299275"
+  integrity sha512-MiaYQU8CwVCaOfJdYvt84KQNjT78VF0TJrA17SIQgNHRvLnXDJO6qsFqq8F/zzB1BWZjCFIrQpu4QxcshitziQ==
+  dependencies:
+    "@remix-run/router" "1.0.3"
+    react-router "6.4.3"
+
+react-router@6.4.3:
+  version "6.4.3"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-6.4.3.tgz#9ed3ee4d6e95889e9b075a5d63e29acc7def0d49"
+  integrity sha512-BT6DoGn6aV1FVP5yfODMOiieakp3z46P1Fk0RNzJMACzE7C339sFuHebfvWtnB4pzBvXXkHP2vscJzWRuUjTtA==
+  dependencies:
+    "@remix-run/router" "1.0.3"
 
 react-scripts@4.0.3:
   version "4.0.3"


### PR DESCRIPTION
- [X] Add react-router-dom v6
- [X] Add new `/tx/:txhash` route
- [X] Add redirection for old route (`?t=txhash`)

Expected outcomes:
| URL             | Redirect to | Note                                           |
|-----------------|-------------|------------------------------------------------|
| /tx             | /           |                                                |
| /tx/validHash   | /tx/hash    | input is set with hash, transaction is fetched |
| /tx/invalidHash | /           |                                                |
| ?t=validHash    | /tx/hash    | input is set with hash, transaction is fetched |
| ?t=invalidHash  | /           |                                                |
