### PR TITLE
bug repro: add network/signer log

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -418,6 +418,13 @@ function App() {
 
   const resultRef = useRef<null | HTMLDivElement>(null);
   const { chain } = useNetwork();
+  // @ts-ignore
+  console.log(
+    'useNetwork chain Id:',
+    chain?.id,
+    'useSigner chain id:',
+    signer?.provider?._network.chainId,
+  );
 
   const [input, setInput] = React.useState<string>('');
   const [txHashState, setTxnHashState] = React.useState<ReceiptState>(


### PR DESCRIPTION
When i load the page w/ wallet connected to 42161, I consistently see use signer give a signer w/ network id 1 — can others reproduce?

(This leads to a "underlying network changed" when you try to redeem; as of rn, you can test this with 0xa27715793afc85bbf2142f7538a03c84e1c52456dadf7513bfa6dd16f88bffe3) 