### PR TITLE
add retryables-tracker-all page

### DIFF
--- a/src/app/retryables-tracker-all/layout.tsx
+++ b/src/app/retryables-tracker-all/layout.tsx
@@ -1,0 +1,19 @@
+import { Logo } from '@/components/Logo';
+import { WagmiProvider } from '@/components/WagmiProvider';
+import { PropsWithChildren } from 'react';
+
+export default function Layout({ children }: PropsWithChildren) {
+  return (
+    <>
+      <header>
+        <h1>All pending retryables:</h1>
+
+        <Logo />
+      </header>
+
+      <main>
+        <WagmiProvider>{children}</WagmiProvider>
+      </main>
+    </>
+  );
+}

--- a/src/app/retryables-tracker-all/page.tsx
+++ b/src/app/retryables-tracker-all/page.tsx
@@ -1,0 +1,16 @@
+import { Suspense } from 'react';
+import PendingRetryables from '../retryables-tracker/[address]/PendingRetryables';
+
+const Page = async () => {
+  return (
+    <>
+      <h3>Pending Retryables</h3>
+      <Suspense fallback={<div>Loading...</div>}>
+        {/* @ts-expect-error Server Component */}
+        <PendingRetryables />
+      </Suspense>
+    </>
+  );
+};
+
+export default Page;

--- a/src/app/retryables-tracker/[address]/PendingRetryables.tsx
+++ b/src/app/retryables-tracker/[address]/PendingRetryables.tsx
@@ -3,7 +3,7 @@ import { Retryable, Deposit, BridgeRetryable } from './types';
 import { querySubgraph, subgraphUrl } from './querySubgraph';
 
 async function fetchPendingRetryables(
-  address: string,
+  address?: string,
 ): Promise<`0x${string}`[]> {
   const timestamp = Math.floor(new Date().getTime() / 1000);
   const query = `
@@ -74,20 +74,20 @@ async function fetchPendingRetryables(
     return acc;
   }, {} as { [txHash: string]: Deposit });
 
-  const retryablesWithDeposit = retryables.map((retryable) => {
+  let retryablesWithDeposit = retryables.map((retryable) => {
     const deposit = depositsMap[retryable.transactionHash];
     return deposit ? deposit : retryable;
   });
-
-  return retryablesWithDeposit
-    .filter(
-      (retryable) => retryable.sender.toLowerCase() === address.toLowerCase(),
-    )
-    .map((retryable) => retryable.transactionHash);
+  if (address) {
+    retryablesWithDeposit = retryablesWithDeposit.filter((retryable) => {
+      return retryable.sender.toLowerCase() === address.toLowerCase();
+    });
+  }
+  return retryablesWithDeposit.map((retryable) => retryable.transactionHash);
 }
 
 type Props = {
-  address: string;
+  address?: string;
   limit?: number;
 };
 async function PendingRetryables({ address, limit }: Props) {


### PR DESCRIPTION
creates a /retryables-tracker-all endpoint. not exposed directly in the UI anywhere (even as is will be useful to me tho) 