### PR TITLE
fix: upgrade typescript to resolve syntax errors during tsc

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "react-dom": "^18.2.0",
     "react-feather": "^2.0.10",
     "react-tooltip": "^5.5.1",
-    "typescript": "^4.4.2",
+    "typescript": "^5.3.3",
     "wagmi": "^0.12.19"
   },
   "engines": {


### PR DESCRIPTION
Closes #34

Upgrading `typescript` resolves the `TS1005` syntax parsing error that occurs when `tsc` attempts to parse newer TypeScript syntax in `node_modules` (specifically from `@wagmi/core` types) prior to applying `skipLibCheck`.